### PR TITLE
Correct link to glossary for aid

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -6,7 +6,7 @@ description: Defines terms used in Origin documentation.
 
 _Note: Mostly, this terminology is specific to the Origin platform. Theoretical and formally standardized cryptographic and cybersecurity terms are introduced only lightly. For more details about those concepts, see the_ [_KERI ecosystem_](https://keri.one)_'s_ [_KERISSE website_](https://kerisse.org)_,_ [_GLEIF_](https://gleif.org)_'s_ [_vLEI Governance Framework_](https://www.gleif.org/en/vlei/introducing-the-vlei-ecosystem-governance-framework)_, the_ [_Trust Over IP Glossary_](https://trustoverip.github.io/toip/glossary)_,_ [_Hyperledger Aries RFCs_](https://github.com/hyperledger/aries-rfcs/blob/main/index.md)_, and W3C's_ [_Verifiable Credentials Data Model_](https://www.w3.org/TR/vc-data-model/) _and_ [_Decentralized Identifiers (DIDs)_](https://www.w3.org/TR/did-core/)_._
 
-### aid
+### AID
 
 A self-certifying identifier which cryptographically binds an identifier to a public and private key pair. It is an identifier that can be proven to be the one and only identifier tied to a public key using cryptography alone. A vLEI formally references its issuee by the issuee's AID.
 

--- a/tasks/sign-with-vlei.md
+++ b/tasks/sign-with-vlei.md
@@ -6,7 +6,7 @@ description: what it means to "sign with" a vLEI
 
 In casual speech, we sometimes say that an organization or a person can "sign with" a [vLEI](../concepts/creds/vleis/). We need to define this behavior carefully.
 
-The party that receives a vLEI is called its _issuee_. For LE vLEIs, the issuee is the legal entity (an organization). For OOR and ECR vLEIs, the issuee is an individual who has a specific role at the organization. A vLEI formally references its issuee by their [AID](../../../glossary.md#aid) (a long, hard-to-remember string -- something like`EBMYrQqWyRLAYqMLYv_qm-qP7eKN81Wmjyz5nXQvYLY`).
+The party that receives a vLEI is called its _issuee_. For LE vLEIs, the issuee is the legal entity (an organization). For OOR and ECR vLEIs, the issuee is an individual who has a specific role at the organization. A vLEI formally references its issuee by their [AID](../../glossary.md#aid) (a long, hard-to-remember string -- something like`EBMYrQqWyRLAYqMLYv_qm-qP7eKN81Wmjyz5nXQvYLY`).
 
 The AID of the issuee can be used to look up a cryptographic [public key](https://en.wikipedia.org/wiki/Public-key\_cryptography) controlled by the issuee. The corresponding private key is a secret known only to the issuee. The issuee can use the private key to create digital signatures, and anybody in the world can use the public key to check those signatures. This is how an issuee proves they control the vLEI.
 

--- a/tasks/sign-with-vlei.md
+++ b/tasks/sign-with-vlei.md
@@ -6,7 +6,7 @@ description: what it means to "sign with" a vLEI
 
 In casual speech, we sometimes say that an organization or a person can "sign with" a [vLEI](../concepts/creds/vleis/). We need to define this behavior carefully.
 
-The party that receives a vLEI is called its _issuee_. For LE vLEIs, the issuee is the legal entity (an organization). For OOR and ECR vLEIs, the issuee is an individual who has a specific role at the organization. A vLEI formally references its issuee by their [AID](../../glossary.md#aid) (a long, hard-to-remember string -- something like`EBMYrQqWyRLAYqMLYv_qm-qP7eKN81Wmjyz5nXQvYLY`).
+The party that receives a vLEI is called its _issuee_. For LE vLEIs, the issuee is the legal entity (an organization). For OOR and ECR vLEIs, the issuee is an individual who has a specific role at the organization. A vLEI formally references its issuee by their [AID](../glossary.md#aid) (a long, hard-to-remember string -- something like`EBMYrQqWyRLAYqMLYv_qm-qP7eKN81Wmjyz5nXQvYLY`).
 
 The AID of the issuee can be used to look up a cryptographic [public key](https://en.wikipedia.org/wiki/Public-key\_cryptography) controlled by the issuee. The corresponding private key is a secret known only to the issuee. The issuee can use the private key to create digital signatures, and anybody in the world can use the public key to check those signatures. This is how an issuee proves they control the vLEI.
 


### PR DESCRIPTION
Corrected link to Glossary for AID
Capitalized AID in Glossary